### PR TITLE
Fix set comparison

### DIFF
--- a/src/arrangement/core.cljc
+++ b/src/arrangement/core.cljc
@@ -106,7 +106,7 @@
         (set? a)
         (let [size-diff (- (count a) (count b))]
           (if (zero? size-diff)
-            (compare-seqs a b)
+            (compare-seqs (sort a) (sort b))
             size-diff))
 
         (coll? a)

--- a/src/arrangement/core.cljc
+++ b/src/arrangement/core.cljc
@@ -59,16 +59,14 @@
   sequences orders differently, it determines the ordering. Otherwise, if the
   prefix matches, the longer sequence sorts later."
   [xs ys]
-  (loop [xs xs
-         ys ys]
-    (if (and (seq xs) (seq ys))
-      (let [x (first xs)
-            y (first ys)
-            o (rank x y)]
-        (if (zero? o)
-          (recur (next xs) (next ys))
-          o))
-      (- (count xs) (count ys)))))
+  (if (and (seq xs) (seq ys))
+    (let [x (first xs)
+          y (first ys)
+          o (rank x y)]
+      (if (zero? o)
+        (recur (next xs) (next ys))
+        o))
+    (- (count xs) (count ys))))
 
 
 (defn rank

--- a/test/arrangement/core_test.cljc
+++ b/test/arrangement/core_test.cljc
@@ -43,7 +43,7 @@
 
 (deftest set-ordering
   (is-sorted
-    #{:one} #{:two} #{:zzz} #{:one :two} #{:one :zzz}))
+    #{:one} #{:two} #{:zzz} #{:one :two} #{:one :zzz} #{:a :e :f} #{:b :c :d}))
 
 
 (deftest map-ordering


### PR DESCRIPTION
The docstring for `rank` states "Sets are compared by cardinality first, then elements in sorted order",
yet there is nothing enforcing any particular order on the sets when they are compared.

This adds a couple of sets to the `set-ordering` test to make it fail, then fixes that so that sets are compared in order as specified in the docstring.

The only potential issue I see is that when this is used in `(sort oder/rank ...)`, elements that are sets could end up getting sorted numerous times, which could be quite inefficient. However I can't see an easy way around that, other than maybe memoizing the set sorting - but that would come with its own issues (e.g. memory usage).

While there I also noticed a redundant `loop` - it can be removed and the `recur` will just recur into the function, that has identical arguments to the loop.